### PR TITLE
jobset-generator/hydra_types: field unification

### DIFF
--- a/jobset-generator/src/hydra_types.rs
+++ b/jobset-generator/src/hydra_types.rs
@@ -42,6 +42,8 @@ pub struct HydraJobset {
     pub definition: HydraInputDefinition,
 }
 
+// XXX: This struct is a representation that Hydra's underlying database schema understands, **NOT**
+// its REST API. Changes made to reflect what the API wants **WILL NOT WORK AS EXPECTED**.
 #[derive(Debug, Serialize)]
 pub struct FlattenedHydraJobset {
     pub enabled: bool,


### PR DESCRIPTION
##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

While playing with this and Hydra, I noticed the following log:

    14:08:21 hydra-notify.1       | ERROR: failed to process declarative jobset test:pr-2, {UNKNOWN}: invalid keys (HASH(0x6f660c8)) in declarative specification file at /nix/store/aa6gw57fnahd4824pbhmvcs0jlypmynq-hydra-perl-deps/lib/perl5/site_perl/5.32.1/Catalyst/Model/DBIC/Schema.pm line 526

With this commit, that line is gone.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [ ] Checked the rust with `cargo build`, `cargo test`, `cargo fmt`, and `cargo clippy` in the jobset-generator directory
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` in the terraform directory
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
