### PR TITLE
make_flake_definition: replace the first : with a /

### DIFF
--- a/jobset-generator/src/pr_builder.rs
+++ b/jobset-generator/src/pr_builder.rs
@@ -15,7 +15,7 @@ pub fn make_flake_definition(_job_config: JobConfig, pr: PullRequest) -> HydraIn
     HydraInputDefinition::Flake(HydraJobsetFlake {
         flake_uri: format!(
             "git+ssh://{}?{}",
-            pr.head.repo.ssh_url,
+            pr.head.repo.ssh_url.replacen(":", "/", 1),
             url_encoded_data::stringify(&[("ref", &pr.head.r#ref), ("rev", &pr.head.sha)])
         ),
     })


### PR DESCRIPTION
Converts `git+ssh://git@github.com:DeterminateSystems/xxx.git?ref=grahamc-patch-1` to `git+ssh://git@github.com/DeterminateSystems/xxx.git?ref=grahamc-patch-1`

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [ ] Checked the rust with `cargo build`, `cargo test`, `cargo fmt`, and `cargo clippy` in the jobset-generator directory
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` in the terraform directory
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
