### PR TITLE
readme: use https:// for fetching nixpkgs, not git://

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In your project's repository, create a file at `.hydra/project.json`. This conta
         },
         "nixpkgs": {
             "type": "git",
-            "value": "git://github.com/NixOS/nixpkgs.git nixos-unstable-small",
+            "value": "https://github.com/NixOS/nixpkgs.git nixos-unstable-small",
             "emailresponsible": false
         },
         "pull_requests": {


### PR DESCRIPTION
##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [ ] Checked the rust with `cargo build`, `cargo test`, `cargo fmt`, and `cargo clippy` in the jobset-generator directory
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` in the terraform directory
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
