### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Check Spelling
       run: nix develop --command codespell --ignore-words-list crate,pullrequest,pullrequests .
 
@@ -23,8 +22,8 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Terraform fmt
         run: nix-shell --run 'terraform fmt -check -recursive ./terraform'
       - name: Terraform init
@@ -38,8 +37,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Enable magic Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Check rustfmt
       working-directory: jobset-generator/
       run: nix-shell ../shell.nix --run 'cargo fmt -- --check'
@@ -57,8 +56,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Enable magic Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Check Formatting
       run: nix develop --command nixpkgs-fmt .
 
@@ -68,7 +67,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Enable magic Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Check Formatting
       run: nix build -L .#generator.x86_64-linux

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,9 +8,13 @@ jobs:
   lockfile:
     runs-on: ubuntu-22.04
     steps:
-      - name: Update flake.lock
+      - name: Checkout
         uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: DeterminateSystems/flake-checker-action@main
-      - uses: DeterminateSystems/update-flake-lock@main
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Check flake
+        uses: DeterminateSystems/flake-checker-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,13 +6,11 @@ on:
 
 jobs:
   lockfile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v9
+        uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - uses: DeterminateSystems/update-flake-lock@main


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
