### PR TITLE
Try pr refname instead of sha

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       pkgsFor = pkgs: system:
         import pkgs { inherit system; };
 
-      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      allSystems = [ "x86_64-linux" "aarch64-darwin" "aarch64-linux" "x86_64-darwin" ];
       forAllSystems = f: genAttrs allSystems
         (system: f {
           inherit system;

--- a/jobset-generator/src/pr_builder.rs
+++ b/jobset-generator/src/pr_builder.rs
@@ -27,7 +27,7 @@ pub fn make_legacy_definition(job_config: JobConfig, pr: PullRequest) -> HydraIn
         job_config.inputname.clone(),
         HydraJobsetInput {
             r#type: String::from("git"),
-            value: format!("{} {}", pr.head.repo.git_url, pr.head.sha),
+            value: format!("{} {}", pr.head.repo.git_url, pr.head.r#ref),
             emailresponsible: job_config.email_responsible,
         },
     );


### PR DESCRIPTION
##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

I noticed long long turnaround times (and confusion issues when we used force pushes on PRs) until the generated jobs picked up new commits.

I switched to using the branch name associated with a PR so that we remove one level of indirection and users can quickly push "evaluate this" in the hydra menu and get the most up to date version.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

didn't do those yet, but it works on my hydra. happy to spend some time cleaning up if this is something you'd like to pick up.

- [ ] Checked the rust with `cargo build`, `cargo test`, `cargo fmt`, and `cargo clippy` in the jobset-generator directory
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` in the terraform directory
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
